### PR TITLE
Add SpeicalVirtium vendor utility, for Virtium SSD which doesn't support SmartCMD

### DIFF
--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -79,15 +79,16 @@ class SsdUtil(StorageCommon):
         self.log = syslogger.SysLogger(self.log_identifier)
 
         self.vendor_ssd_utility = {
-            "Generic"  : { "utility" : SMARTCTL, "parser" : self.parse_generic_ssd_info },
-            "InnoDisk" : { "utility" : INNODISK, "parser" : self.parse_innodisk_info },
-            "M.2"      : { "utility" : INNODISK, "parser" : self.parse_innodisk_info },
-            "StorFly"  : { "utility" : VIRTIUM,  "parser" : self.parse_virtium_info },
-            "Virtium"  : { "utility" : VIRTIUM,  "parser" : self.parse_virtium_info },
-            "Swissbit" : { "utility" : SMARTCTL, "parser" : self.parse_swissbit_info },
-            "Micron"   : { "utility" : SMARTCTL, "parser" : self.parse_micron_info },
-            "Intel"    : { "utility" : SMARTCTL, "parser" : self.parse_intel_info },
-            "Transcend" : { "utility" : TRANSCEND, "parser" : self.parse_transcend_info },
+            "Generic"           : { "utility" : SMARTCTL, "parser" : self.parse_generic_ssd_info },
+            "InnoDisk"          : { "utility" : INNODISK, "parser" : self.parse_innodisk_info },
+            "M.2"               : { "utility" : INNODISK, "parser" : self.parse_innodisk_info },
+            "StorFly"           : { "utility" : VIRTIUM,  "parser" : self.parse_virtium_info },
+            "Virtium"           : { "utility" : VIRTIUM,  "parser" : self.parse_virtium_info },
+            "SpecialVirtium"    : { "utility" : SMARTCTL,  "parser" : self.parse_generic_ssd_info },
+            "Swissbit"          : { "utility" : SMARTCTL, "parser" : self.parse_swissbit_info },
+            "Micron"            : { "utility" : SMARTCTL, "parser" : self.parse_micron_info },
+            "Intel"             : { "utility" : SMARTCTL, "parser" : self.parse_intel_info },
+            "Transcend"         : { "utility" : TRANSCEND, "parser" : self.parse_transcend_info },
         }
 
         self.dev = diskdev
@@ -103,7 +104,10 @@ class SsdUtil(StorageCommon):
 
         # Known vendor part
         if self.model:
-            vendor = self._parse_vendor()
+            if self.model in ['Virtium VTPM24CEXI080-BM110006']:
+                vendor = 'SpecialVirtium'
+            else:
+                vendor = self._parse_vendor()
             if vendor:
                 try:
                     self.fetch_vendor_ssd_info(diskdev, vendor)


### PR DESCRIPTION
…

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Add SpecialVirtium Vendor to vendor_ssd_utility map, to support Virtium SSD which can't use SmartCMD.
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
There are Virtium SSDs which can't receive SSD info from 'SmartCMD', and must use 'smartctl' command. 
For those SSDs, a new option was added, to use SpecialVirtium vendor which will parse 'smartctl'.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
I tested it manually with a special Virtium SSD which doesn't support SmartCMD

#### Additional Information (Optional)
output after the change:
root@sonic:/home/admin# show platform ssdhealth 
Device Model : Virtium VTPM24CEXI080-BM110006
Health       : 100.0%
Temperature  : 45.0C


